### PR TITLE
use the new Moose::Util::MetaRole API instead of the old one

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -7,7 +7,7 @@ all_from 'lib/Orochi.pm';
 
 requires 'namespace::clean';
 requires 'Data::Visitor';
-requires 'Moose' => '0.90';
+requires 'Moose' => '0.93_01';
 requires 'Module::Pluggable';
 requires 'Path::Router';
 requires 'Sub::Exporter';

--- a/lib/MooseX/Orochi.pm
+++ b/lib/MooseX/Orochi.pm
@@ -20,8 +20,11 @@ sub init_meta {
             ->apply( $meta )
         ;
     } else {
-        Moose::Util::MetaRole::apply_metaclass_roles(@_,
-            metaclass_roles => [ 'MooseX::Orochi::Meta::Class' ]
+        Moose::Util::MetaRole::apply_metaroles(
+            for             => $args{for_class},
+            class_metaroles => {
+                class => [ 'MooseX::Orochi::Meta::Class' ],
+            },
         );
     }
     $meta;


### PR DESCRIPTION
use apply_metaroles() function instead of apply_metaclass_roles()
to pass tests with Moose 2.0200+.
